### PR TITLE
feat: YTDLP_COOKIES_CONTENT for cloud agent YouTube cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,5 +26,7 @@ FIREBASE_PRIVATE_KEY=<to_be_filled_for_ladder>
 # YouTube / yt-dlp (optional, avoids bot blocks)
 # Option A — local dev: reuse browser session
 # YTDLP_COOKIES_BROWSER=chrome
-# Option B — automation/cloud: path to exported cookies.txt (Netscape format)
+# Option B — cloud/automation: paste cookies.txt content (Netscape format)
+# YTDLP_COOKIES_CONTENT=
+# Option C — local file path
 # YTDLP_COOKIES_FILE=./secrets/youtube-cookies.txt

--- a/agents.md
+++ b/agents.md
@@ -15,5 +15,6 @@ Never translate. We already have a script that do that yarn i18n.
 - These scripts call the local `yt-dlp` binary directly (no Docker). `ffmpeg`/`ffprobe` is installed system-wide.
 - `./scripts/get-music-durations.sh` uses `ffprobe`.
 - `yarn mp3` (`scripts/youtube-downloader/download.ts`), `yarn playlist`, and `yarn check-zzz-playlists` use `yt-dlp` via the shared helper `scripts/youtube-downloader/ytdlp.ts`. `yt-dlp` must be on `PATH` (the update script installs it to `/usr/local/bin`).
+- YouTube cookies for cloud agents: set `YTDLP_COOKIES_CONTENT` in Cursor environment secrets with the full `cookies.txt` content (see `scripts/ask-musics/agents.md`).
 - `yarn mp3` reads URLs from `scripts/youtube-downloader/files-to-download.txt` and writes MP3s to `scripts/youtube-downloader/files/`.
 - From a cloud/datacenter IP, YouTube often returns "Sign in to confirm you're not a bot"; downloads then need cookies (`--cookies`/`--cookies-from-browser`), and recent `yt-dlp` may also warn about needing a JS runtime (e.g. deno). These are YouTube/yt-dlp limitations, not environment problems — non-YouTube direct media URLs download fine.

--- a/scripts/ask-musics/agents.md
+++ b/scripts/ask-musics/agents.md
@@ -61,14 +61,17 @@ yarn ask-musics:process-pending --url "https://www.youtube.com/watch?v=..." --dr
 1. Install a cookies exporter extension in Chrome (e.g. "Get cookies.txt LOCALLY")
 2. Go to [youtube.com](https://www.youtube.com) while logged in
 3. Export cookies as `cookies.txt` (Netscape format)
-4. Save the file **outside the repo** (e.g. `~/secrets/youtube-cookies.txt`)
-5. Add to Cursor environment secrets:
+4. Add the file content to Cursor environment secrets:
 
 ```bash
-YTDLP_COOKIES_FILE=/path/to/youtube-cookies.txt
+YTDLP_COOKIES_CONTENT=<paste full cookies.txt content here>
 ```
 
-Or in the project's `.env` (gitignored):
+Cursor secrets support multiline values. If newlines are escaped, the script normalizes `\n` automatically.
+
+### Option C — Local file path
+
+Save the exported file outside the repo (e.g. `~/secrets/youtube-cookies.txt`) or in the project:
 
 ```bash
 YTDLP_COOKIES_FILE=./secrets/youtube-cookies.txt
@@ -76,7 +79,7 @@ YTDLP_COOKIES_FILE=./secrets/youtube-cookies.txt
 
 Add `secrets/` to `.gitignore` if you store cookies locally.
 
-**Priority:** `YTDLP_COOKIES_FILE` overrides `YTDLP_COOKIES_BROWSER` if both are set.
+**Priority:** `YTDLP_COOKIES_FILE` > `YTDLP_COOKIES_CONTENT` > `YTDLP_COOKIES_BROWSER`
 
 Cookies expire — re-export every few weeks if downloads start failing again.
 

--- a/scripts/ask-musics/lib/youtube.ts
+++ b/scripts/ask-musics/lib/youtube.ts
@@ -1,31 +1,12 @@
 import { mkdir, readdir, rename, unlink } from "fs/promises";
 import { dirname, join } from "path";
+import { getYtdlpExtraArgs } from "../../youtube-downloader/ytdlp-cookies";
 import { requireCmd, runCommand, runCommandCapture, ytdlpBin } from "../../youtube-downloader/ytdlp";
 
 const DOWNLOAD_DIR = join(
   process.cwd(),
   "scripts/youtube-downloader/files"
 );
-
-function getYtdlpExtraArgs(): string[] {
-  const args: string[] = [];
-
-  const js_runtime = process.env.YTDLP_JS_RUNTIME?.trim() || "node";
-  args.push("--js-runtimes", js_runtime);
-
-  const cookies_file = process.env.YTDLP_COOKIES_FILE?.trim();
-  if (cookies_file) {
-    args.push("--cookies", cookies_file);
-    return args;
-  }
-
-  const browser = process.env.YTDLP_COOKIES_BROWSER?.trim();
-  if (browser) {
-    args.push("--cookies-from-browser", browser);
-  }
-
-  return args;
-}
 
 function extractYtdlpError(stderr: string, fallback: string): string {
   const errorLine = stderr
@@ -47,7 +28,7 @@ export async function fetchYoutubeMetadata(url: string): Promise<YoutubeMetadata
   await requireCmd(ytdlpBin);
 
   const { code, stdout, stderr } = await runCommandCapture(ytdlpBin, [
-    ...getYtdlpExtraArgs(),
+    ...(await getYtdlpExtraArgs()),
     "--no-playlist",
     "--print",
     "%(id)s",
@@ -85,7 +66,7 @@ export async function downloadYoutubeMp3(url: string): Promise<string> {
   const before = new Set(await readdir(DOWNLOAD_DIR));
 
   const code = await runCommand(ytdlpBin, [
-    ...getYtdlpExtraArgs(),
+    ...(await getYtdlpExtraArgs()),
     "--no-progress",
     "--no-playlist",
     "--restrict-filenames",

--- a/scripts/youtube-downloader/ytdlp-cookies.ts
+++ b/scripts/youtube-downloader/ytdlp-cookies.ts
@@ -1,0 +1,57 @@
+import { mkdir, writeFile } from "fs/promises";
+import { join } from "path";
+
+let resolvedCookiesFile: string | null | undefined;
+
+function normalizeCookieContent(content: string): string {
+  return content.replace(/\\n/g, "\n").trimEnd() + "\n";
+}
+
+export async function resolveYtdlpCookiesFile(): Promise<string | null> {
+  if (resolvedCookiesFile !== undefined) {
+    return resolvedCookiesFile;
+  }
+
+  const explicitFile = process.env.YTDLP_COOKIES_FILE?.trim();
+  if (explicitFile) {
+    resolvedCookiesFile = explicitFile;
+    return explicitFile;
+  }
+
+  const content = process.env.YTDLP_COOKIES_CONTENT?.trim();
+  if (content) {
+    const dir = join(process.cwd(), "secrets");
+    const filePath = join(dir, "youtube-cookies.txt");
+
+    await mkdir(dir, { recursive: true });
+    await writeFile(filePath, normalizeCookieContent(content), {
+      mode: 0o600,
+    });
+
+    resolvedCookiesFile = filePath;
+    return filePath;
+  }
+
+  resolvedCookiesFile = null;
+  return null;
+}
+
+export async function getYtdlpExtraArgs(): Promise<string[]> {
+  const args: string[] = [];
+
+  const js_runtime = process.env.YTDLP_JS_RUNTIME?.trim() || "node";
+  args.push("--js-runtimes", js_runtime);
+
+  const cookies_file = await resolveYtdlpCookiesFile();
+  if (cookies_file) {
+    args.push("--cookies", cookies_file);
+    return args;
+  }
+
+  const browser = process.env.YTDLP_COOKIES_BROWSER?.trim();
+  if (browser) {
+    args.push("--cookies-from-browser", browser);
+  }
+
+  return args;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `YTDLP_COOKIES_CONTENT` so YouTube cookies can be injected directly from a Cursor environment secret, without uploading a file to the VM.

## How it works

Priority: `YTDLP_COOKIES_FILE` > `YTDLP_COOKIES_CONTENT` > `YTDLP_COOKIES_BROWSER`

When `YTDLP_COOKIES_CONTENT` is set, the script writes the Netscape-format content to `secrets/youtube-cookies.txt` (mode 600) and passes it to yt-dlp.

## Cursor Cloud setup

1. Export `cookies.txt` from Chrome (logged into YouTube)
2. In Cloud Agent environment secrets, add `YTDLP_COOKIES_CONTENT` with the full cookies.txt content
3. `yarn ask-musics:process-pending` works without manual file upload

Escaped newlines (`\n`) in the secret are normalized automatically.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4ceca8f-a552-45e3-a97a-b9f27fa82e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4ceca8f-a552-45e3-a97a-b9f27fa82e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

