### PR TITLE
fix: normalize YTDLP cookies without Netscape header

### DIFF
--- a/scripts/youtube-downloader/download.ts
+++ b/scripts/youtube-downloader/download.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { getYtdlpExtraArgs } from "./ytdlp-cookies";
 import { requireCmd, runCommand, ytdlpBin } from "./ytdlp";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -75,6 +76,7 @@ async function main() {
     console.log(`Downloading: ${url}`);
 
     const code = await runCommand(ytdlpBin, [
+      ...(await getYtdlpExtraArgs()),
       "--no-progress",
       "--ignore-errors",
       "--continue",

--- a/scripts/youtube-downloader/ytdlp-cookies.ts
+++ b/scripts/youtube-downloader/ytdlp-cookies.ts
@@ -3,8 +3,20 @@ import { join } from "path";
 
 let resolvedCookiesFile: string | null | undefined;
 
+const NETSCAPE_COOKIE_HEADER = "# Netscape HTTP Cookie File";
+
 function normalizeCookieContent(content: string): string {
-  return content.replace(/\\n/g, "\n").trimEnd() + "\n";
+  const normalized = content.replace(/\\n/g, "\n").trimEnd();
+
+  if (!normalized) {
+    return "";
+  }
+
+  if (normalized.startsWith(NETSCAPE_COOKIE_HEADER)) {
+    return `${normalized}\n`;
+  }
+
+  return `${NETSCAPE_COOKIE_HEADER}\n${normalized}\n`;
 }
 
 export async function resolveYtdlpCookiesFile(): Promise<string | null> {

--- a/scripts/youtube-downloader/ytdlp.ts
+++ b/scripts/youtube-downloader/ytdlp.ts
@@ -1,4 +1,5 @@
 import { spawn } from "child_process";
+import { getYtdlpExtraArgs } from "./ytdlp-cookies";
 
 export const ytdlpBin = "yt-dlp";
 
@@ -66,6 +67,7 @@ export async function ytdlpPrint(
   printFormat: string
 ): Promise<string> {
   const { code, stdout, stderr } = await runCommandCapture(ytdlpBin, [
+    ...(await getYtdlpExtraArgs()),
     "--flat-playlist",
     "--print",
     printFormat,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloud-agent YouTube downloads were failing because `YTDLP_COOKIES_CONTENT` was missing the required Netscape header line (`# Netscape HTTP Cookie File`), which `yt-dlp` rejects.

This PR:
- Auto-prepends the Netscape header when exporting cookies from `YTDLP_COOKIES_CONTENT`
- Passes cookie/JS runtime args through `yarn mp3` and shared `ytdlpPrint` helpers (previously only `ask-musics` used cookies)

## Test plan

- [x] Verified metadata fetch works from cloud with injected `YTDLP_COOKIES_CONTENT`
- [x] Verified full MP3 download works with cookies + Node JS runtime
- [x] Verified normalization adds the Netscape header automatically
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfdeae4b-9e93-488f-b97f-77753630e232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfdeae4b-9e93-488f-b97f-77753630e232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

