### PR TITLE
feat(ask-musics): Discord notifications for automation runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,6 @@ FIREBASE_PRIVATE_KEY=<to_be_filled_for_ladder>
 # YTDLP_COOKIES_CONTENT=
 # Option C — local file path
 # YTDLP_COOKIES_FILE=./secrets/youtube-cookies.txt
+
+# Discord webhook for ask-music automation logs (start, queue, finish, errors)
+# ASK_MUSIC_DISCORD_WEBHOOK_URL=

--- a/agents.md
+++ b/agents.md
@@ -16,5 +16,6 @@ Never translate. We already have a script that do that yarn i18n.
 - `./scripts/get-music-durations.sh` uses `ffprobe`.
 - `yarn mp3` (`scripts/youtube-downloader/download.ts`), `yarn playlist`, and `yarn check-zzz-playlists` use `yt-dlp` via the shared helper `scripts/youtube-downloader/ytdlp.ts`. `yt-dlp` must be on `PATH` (the update script installs it to `/usr/local/bin`).
 - YouTube cookies for cloud agents: set `YTDLP_COOKIES_CONTENT` in Cursor environment secrets with the full `cookies.txt` content (see `scripts/ask-musics/agents.md`).
+- Ask-music Discord logs: set `ASK_MUSIC_DISCORD_WEBHOOK_URL` in Cursor environment secrets (see `scripts/ask-musics/agents.md`).
 - `yarn mp3` reads URLs from `scripts/youtube-downloader/files-to-download.txt` and writes MP3s to `scripts/youtube-downloader/files/`.
 - From a cloud/datacenter IP, YouTube often returns "Sign in to confirm you're not a bot"; downloads then need cookies (`--cookies`/`--cookies-from-browser`), and recent `yt-dlp` may also warn about needing a JS runtime (e.g. deno). These are YouTube/yt-dlp limitations, not environment problems — non-YouTube direct media URLs download fine.

--- a/scripts/ask-musics/agents.md
+++ b/scripts/ask-musics/agents.md
@@ -97,3 +97,18 @@ yarn ask-musics:process-pending
 ```
 
 Exit code `1` if any request failed. Exit code `0` if all processed or nothing pending.
+
+### Discord notifications
+
+When `ASK_MUSIC_DISCORD_WEBHOOK_URL` is set, the pipeline posts to Discord:
+
+1. **Start** — automation started with the list of pending URLs
+2. **Per-request error** — when a single request fails during processing
+3. **Finish** — summary with added / skipped / failed counts and per-URL results
+4. **Fatal error** — when the script crashes before finishing (e.g. Firestore unavailable)
+
+Add the webhook URL to Cursor environment secrets or `.env`:
+
+```bash
+ASK_MUSIC_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+```

--- a/scripts/ask-musics/lib/discord.ts
+++ b/scripts/ask-musics/lib/discord.ts
@@ -1,0 +1,152 @@
+import { AskMusicRequest } from "../types";
+import { ProcessResult } from "./process-result";
+
+const DISCORD_WEBHOOK_URL = process.env.ASK_MUSIC_DISCORD_WEBHOOK_URL?.trim();
+const DISCORD_MESSAGE_LIMIT = 2000;
+
+type DiscordEmbed = {
+  title: string;
+  description: string;
+  color: number;
+};
+
+function truncateMessage(content: string): string {
+  if (content.length <= DISCORD_MESSAGE_LIMIT) {
+    return content;
+  }
+
+  return `${content.slice(0, DISCORD_MESSAGE_LIMIT - 3)}...`;
+}
+
+async function sendDiscordPayload(payload: {
+  content?: string;
+  embeds?: DiscordEmbed[];
+}): Promise<void> {
+  if (!DISCORD_WEBHOOK_URL) {
+    return;
+  }
+
+  try {
+    const response = await fetch(DISCORD_WEBHOOK_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      console.warn(
+        `Discord webhook failed (${response.status}): ${body || response.statusText}`
+      );
+    }
+  } catch (error) {
+    console.warn("Failed to send Discord notification:", error);
+  }
+}
+
+function formatRequestList(requests: AskMusicRequest[]): string {
+  return requests
+    .map((request, index) => {
+      const users =
+        request.users.length > 0
+          ? ` (${request.users.length} user${request.users.length > 1 ? "s" : ""})`
+          : "";
+
+      return `${index + 1}. ${request.url}${users}`;
+    })
+    .join("\n");
+}
+
+export async function notifyAskMusicStarted({
+  requests,
+  is_dry_run,
+}: {
+  requests: AskMusicRequest[];
+  is_dry_run: boolean;
+}): Promise<void> {
+  const mode = is_dry_run ? " (dry-run)" : "";
+  const list = formatRequestList(requests);
+
+  await sendDiscordPayload({
+    embeds: [
+      {
+        title: `Ask Music automation started${mode}`,
+        description: truncateMessage(
+          `Processing **${requests.length}** request(s):\n\n${list}`
+        ),
+        color: 0x5865f2,
+      },
+    ],
+  });
+}
+
+export async function notifyAskMusicRequestFailed({
+  url,
+  message,
+}: {
+  url: string;
+  message: string;
+}): Promise<void> {
+  await sendDiscordPayload({
+    embeds: [
+      {
+        title: "Ask Music request failed",
+        description: truncateMessage(`**URL:** ${url}\n**Error:** ${message}`),
+        color: 0xed4245,
+      },
+    ],
+  });
+}
+
+export async function notifyAskMusicFinished({
+  results,
+  is_dry_run,
+}: {
+  results: ProcessResult[];
+  is_dry_run: boolean;
+}): Promise<void> {
+  const added = results.filter((result) => result.status === "added").length;
+  const skipped = results.filter((result) => result.status === "skipped").length;
+  const failed = results.filter((result) => result.status === "failed").length;
+  const mode = is_dry_run ? " (dry-run)" : "";
+  const has_failures = failed > 0;
+
+  const lines = results.map((result) => {
+    const icon =
+      result.status === "added"
+        ? "✅"
+        : result.status === "skipped"
+          ? "⏭️"
+          : "❌";
+
+    return `${icon} ${result.url}\n   ${result.message}`;
+  });
+
+  await sendDiscordPayload({
+    embeds: [
+      {
+        title: `Ask Music automation finished${mode}`,
+        description: truncateMessage(
+          [
+            `**Summary:** ${added} added, ${skipped} skipped, ${failed} failed`,
+            "",
+            ...lines,
+          ].join("\n")
+        ),
+        color: has_failures ? 0xfaa61a : 0x57f287,
+      },
+    ],
+  });
+}
+
+export async function notifyAskMusicError(message: string): Promise<void> {
+  await sendDiscordPayload({
+    embeds: [
+      {
+        title: "Ask Music automation error",
+        description: truncateMessage(message),
+        color: 0xed4245,
+      },
+    ],
+  });
+}

--- a/scripts/ask-musics/lib/process-result.ts
+++ b/scripts/ask-musics/lib/process-result.ts
@@ -1,0 +1,6 @@
+export type ProcessResult = {
+  url: string;
+  status: "added" | "skipped" | "failed";
+  message: string;
+  title_id?: string;
+};

--- a/scripts/ask-musics/process-pending.ts
+++ b/scripts/ask-musics/process-pending.ts
@@ -19,19 +19,19 @@ import {
   fetchYoutubeMetadata,
   moveDownloadedFile,
 } from "./lib/youtube";
+import {
+  notifyAskMusicError,
+  notifyAskMusicFinished,
+  notifyAskMusicRequestFailed,
+  notifyAskMusicStarted,
+} from "./lib/discord";
+import { ProcessResult } from "./lib/process-result";
 import { AskMusicRequest } from "./types";
 
 type ParsedArgs = {
   url?: string;
   version?: string;
   limit?: number;
-};
-
-type ProcessResult = {
-  url: string;
-  status: "added" | "skipped" | "failed";
-  message: string;
-  title_id?: string;
 };
 
 const args = new Set(process.argv.slice(2));
@@ -223,6 +223,8 @@ async function main() {
       return;
     }
 
+    await notifyAskMusicStarted({ requests, is_dry_run });
+
     console.log(`Processing ${requests.length} request(s)...`);
 
     const results: ProcessResult[] = [];
@@ -232,6 +234,13 @@ async function main() {
       const result = await processRequest(request, parsed.version);
       results.push(result);
       console.log(`  ${result.status}: ${result.message}`);
+
+      if (result.status === "failed") {
+        await notifyAskMusicRequestFailed({
+          url: result.url,
+          message: result.message,
+        });
+      }
     }
 
     const added = results.filter((result) => result.status === "added").length;
@@ -243,11 +252,17 @@ async function main() {
     console.log(`  skipped: ${skipped}`);
     console.log(`  failed: ${failed}`);
 
+    await notifyAskMusicFinished({ results, is_dry_run });
+
     if (failed > 0) {
       process.exit(1);
     }
   } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown error processing pending requests";
+
     console.error("Error processing pending requests:", error);
+    await notifyAskMusicError(message);
     process.exit(1);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Discord webhook notifications to the ask-music automation pipeline (`yarn ask-musics:process-pending`).

When `ASK_MUSIC_DISCORD_WEBHOOK_URL` is set, the script posts:

1. **Start** — automation started with the full list of pending URLs
2. **Per-request error** — immediate alert when a single request fails
3. **Finish** — summary with added / skipped / failed counts and per-URL results
4. **Fatal error** — when the script crashes before finishing

## Setup

Add the webhook URL to Cursor environment secrets or `.env`:

```bash
ASK_MUSIC_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
```

If the variable is not set, notifications are silently skipped (no behavior change).

## Test plan

- [ ] Set `ASK_MUSIC_DISCORD_WEBHOOK_URL` in environment secrets
- [ ] Run `yarn ask-musics:process-pending --dry-run` and verify start + finish messages on Discord
- [ ] Run with a failing URL and verify per-request error + finish summary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-740ff49f-da4e-452e-98f2-3c6b65e5eda3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-740ff49f-da4e-452e-98f2-3c6b65e5eda3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

