### PR TITLE
feat(ask-musics): ZZZ validation guide and YouTube description metadata

### DIFF
--- a/scripts/ask-musics/agents.md
+++ b/scripts/ask-musics/agents.md
@@ -91,24 +91,40 @@ Cookies expire — re-export every few weeks if downloads start failing again.
 - `yt-dlp` and `ffprobe` installed
 - YouTube cookies (see above) if downloads are blocked
 
-## ZZZ validation (required before adding)
+## ZZZ validation (required before downloading)
 
-Only accept tracks that belong to **Zenless Zone Zero**. Read the **video title and description** — that is enough; no need to dig further.
+Only accept tracks that belong to **Zenless Zone Zero**. Validate from the **video title and description** — that is enough; no need to dig further.
 
-### Workflow per pending request
+**Always validate before downloading the MP3.** Do not call `process-pending` without `--dry-run` until ZZZ validation passes.
+
+### Step 1 — Read the YouTube page (before any download)
+
+From cloud/datacenter IPs, `yt-dlp` is often blocked ("Sign in to confirm you're not a bot"). **Do not rely on yt-dlp for the first validation step.**
+
+Read the public YouTube page for the URL (e.g. web fetch / browser) and extract:
+
+- Video **title**
+- Video **description** (if visible on the page)
+
+If `--dry-run` works (yt-dlp returns title + description), you may use it instead — but prefer reading the page when yt-dlp fails.
+
+**Do not say YouTube is "resolved" or "working" until a real `process-pending` run (without `--dry-run`) successfully downloads the MP3.**
+
+### Step 2 — Validate ZZZ, then act
 
 ```bash
-# 1. Inspect metadata (no download, no writes)
-yarn ask-musics:process-pending --url "<youtube-url>" --dry-run
+# After reading title + description from the page:
 
-# 2a. If ZZZ → process for real
+# 2a. If ZZZ → download and add
 yarn ask-musics:process-pending --url "<youtube-url>"
 
-# 2b. If not ZZZ → reject with a clear reason
+# 2b. If not ZZZ → reject (no download)
 yarn ask-musics:update-status --url "<youtube-url>" --status cancelled --reason "Not ZZZ music"
 ```
 
-For a daily batch, run `--dry-run` on each pending URL first, validate, then process or cancel before moving to the next request.
+Optional: `yarn ask-musics:process-pending --url "<youtube-url>" --dry-run` to double-check metadata via yt-dlp when cookies work. This is **not** a substitute for reading the page when yt-dlp is blocked.
+
+For a daily batch: list pending → read each page → validate → process or cancel → next request.
 
 ### Accept when title or description mentions
 
@@ -130,7 +146,7 @@ When unsure, prefer **rejecting** with reason `"Not ZZZ music"` rather than addi
 
 ```bash
 yarn ask-musics:list-pending
-# For each URL: --dry-run → validate ZZZ → process or cancel
+# For each URL: read YouTube page → validate ZZZ → process or cancel (never download before validation)
 yarn ask-musics:process-pending
 yarn ask-musics:send-report
 ```

--- a/scripts/ask-musics/agents.md
+++ b/scripts/ask-musics/agents.md
@@ -20,7 +20,7 @@ yarn ask-musics:process-pending --version 2.8
 
 Per request, the pipeline:
 
-1. Fetches YouTube metadata (title, duration)
+1. Fetches YouTube metadata (title, description, channel, duration)
 2. Infers version album from title (or uses `--version`)
 3. Downloads MP3 via yt-dlp
 4. Moves file to `musics/{version}--{title-id}.mp3` (local staging only)
@@ -91,9 +91,46 @@ Cookies expire — re-export every few weeks if downloads start failing again.
 - `yt-dlp` and `ffprobe` installed
 - YouTube cookies (see above) if downloads are blocked
 
+## ZZZ validation (required before adding)
+
+Only accept tracks that belong to **Zenless Zone Zero**. Read the **video title and description** — that is enough; no need to dig further.
+
+### Workflow per pending request
+
+```bash
+# 1. Inspect metadata (no download, no writes)
+yarn ask-musics:process-pending --url "<youtube-url>" --dry-run
+
+# 2a. If ZZZ → process for real
+yarn ask-musics:process-pending --url "<youtube-url>"
+
+# 2b. If not ZZZ → reject with a clear reason
+yarn ask-musics:update-status --url "<youtube-url>" --status cancelled --reason "Not ZZZ music"
+```
+
+For a daily batch, run `--dry-run` on each pending URL first, validate, then process or cancel before moving to the next request.
+
+### Accept when title or description mentions
+
+- `Zenless Zone Zero`, `ZZZ`, `ゼンレスゾーンゼロ`
+- Official publisher: `HoYoverse`, `miHoYo`, `COGNOSPHERE`
+- ZZZ soundtrack context: `OST`, `Agent Story`, `EP -`, `Battle Theme`, `Exploration Theme`
+- Known ZZZ character names (e.g. Nicole, Ellen, Yixuan, Yuzuha)
+- Official ZZZ channel or playlist references
+
+### Reject when
+
+- Clearly another game (`Genshin Impact`, `Honkai`, `Wuthering Waves`, etc.) with no ZZZ link
+- Fan cover / remix / unrelated music with no ZZZ mention in title **or** description
+- Title and description together give **no credible link** to Zenless Zone Zero
+
+When unsure, prefer **rejecting** with reason `"Not ZZZ music"` rather than adding unrelated tracks.
+
 ## Automation (Cursor daily)
 
 ```bash
+yarn ask-musics:list-pending
+# For each URL: --dry-run → validate ZZZ → process or cancel
 yarn ask-musics:process-pending
 yarn ask-musics:send-report
 ```

--- a/scripts/ask-musics/lib/youtube.ts
+++ b/scripts/ask-musics/lib/youtube.ts
@@ -18,8 +18,19 @@ function extractYtdlpError(stderr: string, fallback: string): string {
   return errorLine?.replace(/^ERROR:\s*/, "") || fallback;
 }
 
+type YtdlpVideoJson = {
+  id?: string;
+  title?: string;
+  description?: string;
+  channel?: string;
+  uploader?: string;
+  duration?: number;
+};
+
 export type YoutubeMetadata = {
   title: string;
+  description: string;
+  channel: string;
   duration: number;
   video_id: string;
 };
@@ -30,12 +41,7 @@ export async function fetchYoutubeMetadata(url: string): Promise<YoutubeMetadata
   const { code, stdout, stderr } = await runCommandCapture(ytdlpBin, [
     ...(await getYtdlpExtraArgs()),
     "--no-playlist",
-    "--print",
-    "%(id)s",
-    "--print",
-    "%(title)s",
-    "--print",
-    "%(duration)s",
+    "--dump-single-json",
     url,
   ]);
 
@@ -43,19 +49,18 @@ export async function fetchYoutubeMetadata(url: string): Promise<YoutubeMetadata
     throw new Error(extractYtdlpError(stderr, `Failed to fetch metadata for ${url}`));
   }
 
-  const [video_id, title, durationRaw] = stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
+  const data = JSON.parse(stdout) as YtdlpVideoJson;
 
-  if (!video_id || !title) {
+  if (!data.id || !data.title) {
     throw new Error(`Incomplete metadata for ${url}`);
   }
 
   return {
-    video_id,
-    title,
-    duration: Math.round(Number(durationRaw) || 0),
+    video_id: data.id,
+    title: data.title,
+    description: data.description ?? "",
+    channel: data.channel ?? data.uploader ?? "",
+    duration: Math.round(Number(data.duration) || 0),
   };
 }
 

--- a/scripts/ask-musics/process-pending.ts
+++ b/scripts/ask-musics/process-pending.ts
@@ -46,7 +46,7 @@ function printUsage() {
       "  yarn ask-musics:process-pending --url <youtube-url> [--dry-run] [--version <x.y>]",
       "",
       "Pipeline per request:",
-      "  1. Fetch YouTube metadata",
+      "  1. Fetch YouTube metadata (title, description, channel)",
       "  2. Download MP3",
       "  3. Move to musics/ with version prefix",
       "  4. Upload MP3 to R2",
@@ -142,6 +142,10 @@ async function processRequest(
     }
 
     if (is_dry_run) {
+      console.log(`  title: ${metadata.title}`);
+      console.log(`  channel: ${metadata.channel}`);
+      console.log(`  description: ${metadata.description || "(empty)"}`);
+
       return {
         url,
         status: "added",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds **ZZZ validation** workflow to `scripts/ask-musics/agents.md`
- **Read the YouTube page first** (title + description) before any MP3 download — especially when yt-dlp is blocked from cloud IPs
- Extends metadata fetch with description/channel via `yt-dlp --dump-single-json`
- Clarifies: do not claim YouTube is "resolved" until a real `process-pending` download succeeds

## Workflow

1. `yarn ask-musics:list-pending`
2. Per URL: read YouTube page → validate ZZZ
3. If ZZZ → `process-pending`; else → `update-status --status cancelled`
4. `yarn ask-musics:send-report`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d750f15-aee8-4959-b2d9-9f4322ec9991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d750f15-aee8-4959-b2d9-9f4322ec9991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

