### PR TITLE
fix: remove auto focus from ask music dialog

### DIFF
--- a/src/components/modal-ask-music/modal-ask-music.tsx
+++ b/src/components/modal-ask-music/modal-ask-music.tsx
@@ -62,7 +62,6 @@ export const Wrapper: React.FC<ContainerProps> = (props) => {
               }}
             >
               <textarea
-                autoFocus
                 required
                 name="youtube_links"
                 rows={6}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the `autoFocus` prop from the YouTube links textarea in the ask music modal so the keyboard does not open automatically when the dialog is shown.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae95da8c-8de6-490a-b4d2-f2aa38062a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae95da8c-8de6-490a-b4d2-f2aa38062a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

