### PR TITLE
ci: run check workflow on pull requests only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   check:


### PR DESCRIPTION
## Summary
- Remove `push` trigger on `main` from the CI workflow
- Keep `check` on pull requests only (deploy workflow already runs on merge to `main`)

## Test plan
- [ ] CI `check` runs on this PR
- [ ] After merge, pushes to `main` only trigger deploy, not duplicate CI


Made with [Cursor](https://cursor.com)