### PR TITLE
ci: remove sync-music step from deploy workflow

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -29,14 +29,6 @@ jobs:
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install
 
-      - name: Sync musics
-        run: yarn sync-music
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
-          CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
-          CLOUDFLARE_BUCKET_NAME: ${{ secrets.CLOUDFLARE_BUCKET_NAME }}
-
       - name: Sync ladder stats
         run: yarn ladder:stats
         env:


### PR DESCRIPTION
## Summary
- Remove the `yarn sync-music` step from the deploy workflow
- R2 uploads now happen locally (`ask-musics:process-pending` or `yarn sync-music`), and `musics/` is no longer in git

## Test plan
- [ ] CI check passes
- [ ] Deploy workflow still builds and deploys successfully on merge


Made with [Cursor](https://cursor.com)