### PR TITLE
feat(albums): add ask-music tracks from user requests

### DIFF
--- a/src/database/albums/2.6.ts
+++ b/src/database/albums/2.6.ts
@@ -713,4 +713,13 @@ export const Album26Tracks: Track[] = [
     ...Artists["2.6"],
     ...Albums["2.6"],
   },
+  {
+    title: "Nangong Yu Character Demo - \"Full-Combo Angel\"",
+    title_id: "nangong-yu-character-demo-full-combo-angel",
+    source: "/musics/2.6--nangong-yu-character-demo-full-combo-angel.mp3",
+    duration: 125,
+    created_at: new Date("2026-08-06"),
+    ...Artists["2.6"],
+    ...Albums["2.6"],
+  },
 ];

--- a/src/database/albums/3.1.ts
+++ b/src/database/albums/3.1.ts
@@ -243,4 +243,22 @@ export const Album31Tracks: Track[] = [
     ...Artists["3.1"],
     ...Albums["3.1"],
   },
+  {
+    title: "Remielle Character Demo — \"Just Like Old Times\"",
+    title_id: "remielle-character-demo-just-like-old-times",
+    source: "/musics/3.1--remielle-character-demo-just-like-old-times.mp3",
+    duration: 314,
+    created_at: new Date("2026-08-06"),
+    ...Artists["3.1"],
+    ...Albums["3.1"],
+  },
+  {
+    title: "Sixth Street New OST",
+    title_id: "sixth-street-new-ost",
+    source: "/musics/3.1--sixth-street-new-ost.mp3",
+    duration: 480,
+    created_at: new Date("2026-08-06"),
+    ...Artists["3.1"],
+    ...Albums["3.1"],
+  },
 ];

--- a/src/database/albums/nangong-yu.ts
+++ b/src/database/albums/nangong-yu.ts
@@ -30,6 +30,14 @@ export const NangongYuTracks: Track[] = [
     created_at: new Date("2026-03-24"),
     ...Artists["2.7"],
   },
+  {
+    title: "Nangong Yu Character Demo - \"Full-Combo Angel\"",
+    title_id: "nangong-yu-character-demo-full-combo-angel",
+    source: "/musics/2.6--nangong-yu-character-demo-full-combo-angel.mp3",
+    duration: 125,
+    created_at: new Date("2026-08-06"),
+    ...Artists["2.6"],
+  },
 ].map((track) => ({
   ...track,
   ...Albums["nangong-yu"],

--- a/src/database/albums/remielle.ts
+++ b/src/database/albums/remielle.ts
@@ -67,6 +67,14 @@ export const RemielleTracks: Track[] = [
     created_at: new Date("2026-07-31"),
     ...Artists["3.1"],
   },
+  {
+    title: "Remielle Character Demo — \"Just Like Old Times\"",
+    title_id: "remielle-character-demo-just-like-old-times",
+    source: "/musics/3.1--remielle-character-demo-just-like-old-times.mp3",
+    duration: 314,
+    created_at: new Date("2026-08-06"),
+    ...Artists["3.1"],
+  },
 ].map((track) => ({
   ...track,
   ...Albums["remielle"],


### PR DESCRIPTION
## Summary
- Added Nangong Yu Character Demo ("Full-Combo Angel") to 2.6 and nangong-yu albums
- Added Remielle Character Demo ("Just Like Old Times") to 3.1 and remielle albums
- Added Sixth Street New OST to 3.1
- Cancelled 3 duplicate/already-present requests (HoYoFair Vivian, Burning Desires, Korean Remielle demo)

## Test plan
- [ ] Confirm tracks appear in 2.6 / 3.1 / character albums in the app
- [ ] Playback works via R2 CDN for all three new MP3s
- [ ] Ask-music pending queue remains empty


Made with [Cursor](https://cursor.com)